### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ output/
 data/processed/*
 data/raw/digital-exclusion/
 data/raw/population/
+data/raw/floods/*.cpg
+data/raw/floods/*.dbf
+data/raw/floods/*.prj
+data/raw/floods/*.qpj
+data/raw/floods/*.shp
+data/raw/floods/*.shx
+data/raw/low-level-geography-dataset.xlsx
 
 # History files
 .Rhistory

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ install.packages(c(
   "readxl",
   "httr",
   "xml2",
-  "xlsx",
+  "openxlsx",
 
   # for spatial data
   "rgdal",

--- a/prep all data.r
+++ b/prep all data.r
@@ -3,7 +3,7 @@
 ##
 source("prep destitution.r")
 source("prep digital exclusion.r")
-source("prep displacement.r")
+source("prep displacement.r", encoding="utf-8")
 source("prep fires.r")
 source("prep flood risks.r")
 source("prep healthy life expectancy - CCG.r")

--- a/prep combined risks.r
+++ b/prep combined risks.r
@@ -21,7 +21,7 @@ source("init.r")
 quants = 5  # how many fisher splits / quantiles to use
 
 risky_lads_file = file.path(data.dir.out, "Multiple risks in Local Authorities.xlsx")  # Excel file for saving lists of Local Authorities with multiple risks
-
+risky_lads_wb = createWorkbook()
 
 #################################################################################################################
 ## Create list of Local Authorities that have a BRC presence (or not)
@@ -363,7 +363,8 @@ eng_lad_risk_xl = eng_lad_risk %>%
   arrange(desc(`No. 1s`), `Total score`)
 
 # add to Excel file
-write.xlsx(as.data.frame(eng_lad_risk_xl), file = risky_lads_file, sheetName = "England", row.names = F, append = F)
+addWorksheet(risky_lads_wb, "England")
+writeData(risky_lads_wb, sheet="England", x=as.data.frame(eng_lad_risk_xl))
 
 
 #################################################################################################################
@@ -683,7 +684,8 @@ wal_lad_risk_xl = wal_lad_risk %>%
   arrange(desc(`No. 1s`), `Total score`)
 
 # add to Excel file
-write.xlsx(as.data.frame(wal_lad_risk_xl), file = risky_lads_file, sheetName = "Wales", row.names = F, append = T)
+addWorksheet(risky_lads_wb, "Wales")
+writeData(risky_lads_wb, sheet="Wales", x=as.data.frame(wal_lad_risk_xl))
 
 
 #################################################################################################################
@@ -944,7 +946,8 @@ sco_lad_risk_xl = sco_lad_risk %>%
   arrange(desc(`No. 1s`), `Total score`)
 
 # add to Excel file
-write.xlsx(as.data.frame(sco_lad_risk_xl), file = risky_lads_file, sheetName = "Scotland", row.names = F, append = T)
+addWorksheet(risky_lads_wb, "Scotland")
+writeData(risky_lads_wb, sheet="Scotland", x=as.data.frame(sco_lad_risk_xl))
 
 
 #################################################################################################################
@@ -1180,4 +1183,8 @@ ni_lad_risk_xl = ni_lad_risk %>%
   arrange(desc(`No. 1s`), `Total score`)
 
 # add to Excel file
-write.xlsx(as.data.frame(ni_lad_risk_xl), file = risky_lads_file, sheetName = "Northern Ireland", row.names = F, append = T)
+addWorksheet(risky_lads_wb, "Northern Ireland")
+writeData(risky_lads_wb, sheet="Northern Ireland", x=as.data.frame(ni_lad_risk_xl))
+
+# write out Excel file
+saveWorkbook(risky_lads_wb, risky_lads_file, overwrite = T)


### PR DESCRIPTION
Feel free to ignore or cherry pick - suggested minor fixes.

1. Ignore downloaded raw data files (flood shapefiles and a spreadsheet)
2. Fix running `source("prep displacement.r")` - The ellipsis character on line 29 pf prep displacement.r was causing the processing to fail. Running source() with forced UTF-8 encoding fixed it for me.
3. Switch to [`openxlsx`](https://cran.r-project.org/web/packages/openxlsx/index.html) for reading/writing Excel files - this avoids the Java dependency of the xlsx package, which may help with reproducible setup (avoids needing Java install, JAVA_HOME environment variable).

It initially looked like `openxlsx` would be a direct swap-in for `xlsx`, but appending worksheets didn't work as written (each call to `write.xlsx` would overwrite the file and leave it with a single sheet), hence the additional changes to `addWorksheet` and `writeData`.

